### PR TITLE
fix(cli): 'autopg uninstall --help' prints usage; uninstall confirms before pm2 teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ this README and in `console/` use `autopg`.
 autopg [options]                       # foreground server (alias: pgserve)
 autopg daemon                          # long-lived background daemon
 autopg install [--port N] [--data P]   # register pgserve under pm2
-autopg uninstall                       # remove from pm2 (data dir kept)
+autopg uninstall [--yes]               # remove from pm2 (data dir kept); confirms first
 autopg status                          # pm2 + on-disk config snapshot
 autopg url | autopg port               # canonical connection string / port
 autopg config <list|get|set|edit|path|init>   # manage ~/.autopg/settings.json
@@ -254,7 +254,7 @@ autopg install --data /data/pg    # custom data dir
 autopg url                        # postgres://localhost:8432/postgres
 autopg port                       # 8432
 autopg status                     # pm2 + on-disk config snapshot
-autopg uninstall                  # remove from pm2; keep data dir
+autopg uninstall                  # remove from pm2; keep data dir (prompts; --yes for scripts)
 ```
 
 **Hardened defaults** (tuned for production-grade Postgres workloads,

--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -1269,7 +1269,11 @@ function dispatch(subcommand, args, ctx) {
       // alongside `src/lib/pm2-args.js` instead of inside this legacy
       // dispatcher. dispatch() returns a Promise here; the wrapper
       // already handles both numeric and Promise returns.
-      return import('./commands/uninstall.js').then((mod) => mod.runUninstall());
+      //
+      // `args` MUST be forwarded (issue #146): without it `--help` was
+      // silently dropped and `autopg uninstall --help` tore down the
+      // postmaster instead of printing usage.
+      return import('./commands/uninstall.js').then((mod) => mod.runUninstall({ argv: args }));
     case 'doctor':
       // pgserve-singleton-no-proxy Group 3: read-only V1. Reports the
       // active supervisor + postmaster reachability + admin.json /

--- a/src/commands/uninstall.js
+++ b/src/commands/uninstall.js
@@ -27,6 +27,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import readline from 'node:readline';
 
 import {
   ADMIN_FILE_MODE,
@@ -164,18 +165,107 @@ function emit(level, msg, silent) {
   stream.write(`autopg: ${msg}\n`);
 }
 
+const UNINSTALL_USAGE = `Usage: autopg uninstall [options]
+
+Stop and remove the pm2-supervised autopg processes (autopg-server, autopg-ui)
+and clear the supervisor record from ~/.autopg/admin.json.
+
+Preserved: the data directory (~/.autopg/data), config.json, settings.json and
+the admin Basic-Auth credentials — \`autopg install\` brings everything back.
+
+Options:
+  -y, --yes    Skip the confirmation prompt. Required on a non-interactive
+               terminal (scripts, CI, pipes).
+  -h, --help   Show this help and exit.
+
+Examples:
+  autopg uninstall          # prompts before stopping the postmaster
+  autopg uninstall --yes    # non-interactive
+`;
+
+const CONFIRM_PROMPT = 'This stops autopg-server/autopg-ui under pm2 (data dir preserved). Continue? [y/N] ';
+
+function printUninstallUsage(stream = process.stdout) {
+  stream.write(UNINSTALL_USAGE);
+}
+
 /**
- * Run the uninstall flow. Returns a numeric exit code.
+ * Parse `autopg uninstall` argv. Pure — exported for tests.
+ *
+ * @param {string[]} [argv]
+ * @returns {{help: boolean, yes: boolean, unknown: string[]}}
+ */
+export function parseUninstallArgs(argv = []) {
+  const out = { help: false, yes: false, unknown: [] };
+  for (const arg of argv) {
+    if (arg === '--help' || arg === '-h') out.help = true;
+    else if (arg === '--yes' || arg === '-y') out.yes = true;
+    else out.unknown.push(arg);
+  }
+  return out;
+}
+
+function isInteractive() {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+function askConfirmation(question) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test(String(answer).trim()));
+    });
+  });
+}
+
+/**
+ * Run the uninstall flow. Resolves to a numeric exit code.
+ *
+ * Order matters (issue #146): `--help` and argument validation return
+ * BEFORE any pm2 call, and the postmaster is only stopped after an explicit
+ * confirmation — an interactive `[y/N]` prompt on a TTY, or `--yes` / `-y`
+ * (mandatory on a non-interactive terminal, which returns 2 otherwise).
  *
  * @param {object} [opts]
+ * @param {string[]} [opts.argv] — the subcommand's arguments (everything
+ *   after `uninstall`).
+ * @param {boolean} [opts.yes] — programmatic equivalent of `--yes`.
  * @param {string} [opts.configDir] — override the autopg config dir (used
  *   by tests; production code should leave this undefined and let env vars
  *   resolve).
  * @param {boolean} [opts.silent] — suppress stdout/stderr writes.
  */
-export function runUninstall(opts = {}) {
+export async function runUninstall(opts = {}) {
   const configDir = opts.configDir || getConfigDir();
   const silent = opts.silent === true;
+  const args = parseUninstallArgs(Array.isArray(opts.argv) ? opts.argv : []);
+
+  if (args.help) {
+    printUninstallUsage(process.stdout);
+    return 0;
+  }
+  if (args.unknown.length > 0) {
+    process.stderr.write(`autopg: uninstall: unknown option ${args.unknown.join(' ')}\n`);
+    printUninstallUsage(process.stderr);
+    return 2;
+  }
+
+  if (!(args.yes || opts.yes === true)) {
+    if (!isInteractive()) {
+      emit(
+        'err',
+        'uninstall stops autopg-server/autopg-ui under pm2 (data dir preserved); refusing without confirmation on a non-interactive terminal. Re-run with --yes.',
+        silent,
+      );
+      return 2;
+    }
+    const confirmed = await askConfirmation(CONFIRM_PROMPT);
+    if (!confirmed) {
+      emit('out', 'uninstall aborted; nothing changed', silent);
+      return 1;
+    }
+  }
 
   const pm2Available = pm2IsAvailable();
   if (!pm2Available) {

--- a/tests/cli-install.test.js
+++ b/tests/cli-install.test.js
@@ -226,7 +226,7 @@ describe('pgserve install', () => {
 
   test('autopg uninstall tears down both autopg-server and autopg-ui', () => {
     runCli(['install']);
-    runCli(['uninstall']);
+    runCli(['uninstall', '--yes']);
     const calls = readCallLog(stubBin.calls);
     const deletes = calls.filter((c) => c[0] === 'delete');
     const deletedNames = deletes.map((c) => c[1]);
@@ -570,7 +570,7 @@ describe('pgserve uninstall', () => {
     runCli(['install']);
     expect(fs.existsSync(path.join(tmpHome, 'config.json'))).toBe(true);
 
-    const result = runCli(['uninstall']);
+    const result = runCli(['uninstall', '--yes']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('uninstalled');
 
@@ -582,7 +582,7 @@ describe('pgserve uninstall', () => {
   });
 
   test('uninstall when not installed is a no-op success', () => {
-    const result = runCli(['uninstall']);
+    const result = runCli(['uninstall', '--yes']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('not registered');
   });

--- a/tests/cli/uninstall.test.js
+++ b/tests/cli/uninstall.test.js
@@ -15,6 +15,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
+import { parseUninstallArgs } from '../../src/commands/uninstall.js';
+
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const BIN = path.join(REPO_ROOT, 'bin', 'autopg-wrapper.cjs');
 
@@ -151,7 +153,7 @@ describe('autopg uninstall — pm2 teardown', () => {
     spawnSync(path.join(stubBin.dir, 'pm2'), ['start', '/dev/null', '--name', 'autopg-server']);
     spawnSync(path.join(stubBin.dir, 'pm2'), ['start', '/dev/null', '--name', 'autopg-ui']);
 
-    const result = runCli(['uninstall']);
+    const result = runCli(['uninstall', '--yes']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('uninstalled');
     expect(result.stdout).toContain('autopg-server');
@@ -168,7 +170,7 @@ describe('autopg uninstall — pm2 teardown', () => {
     fs.writeFileSync(path.join(tmpHome, 'data', 'pgdata-marker'), 'keep-me');
     spawnSync(path.join(stubBin.dir, 'pm2'), ['start', '/dev/null', '--name', 'autopg-server']);
 
-    runCli(['uninstall']);
+    runCli(['uninstall', '--yes']);
 
     expect(fs.existsSync(path.join(tmpHome, 'data', 'pgdata-marker'))).toBe(true);
     expect(fs.readFileSync(path.join(tmpHome, 'data', 'pgdata-marker'), 'utf8')).toBe('keep-me');
@@ -191,7 +193,7 @@ describe('autopg uninstall — admin.json supervisor clear', () => {
       rotatedAt: null,
     });
 
-    const result = runCli(['uninstall']);
+    const result = runCli(['uninstall', '--yes']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('cleared supervisor record');
 
@@ -216,7 +218,7 @@ describe('autopg uninstall — admin.json supervisor clear', () => {
       port: 5432,
       installedAt: '2026-05-08T07:30:00.000Z',
     });
-    const result = runCli(['uninstall']);
+    const result = runCli(['uninstall', '--yes']);
     expect(result.status).toBe(0);
     expect(fs.existsSync(path.join(tmpHome, 'admin.json'))).toBe(false);
   });
@@ -230,7 +232,7 @@ describe('autopg uninstall — admin.json supervisor clear', () => {
       rotatedAt: null,
     });
     const before = readAdminJsonOnDisk();
-    runCli(['uninstall']);
+    runCli(['uninstall', '--yes']);
     const after = readAdminJsonOnDisk();
     expect(after).toEqual(before);
   });
@@ -247,18 +249,18 @@ describe('autopg uninstall — idempotency', () => {
       installedAt: '2026-05-08T07:30:00.000Z',
     });
 
-    const first = runCli(['uninstall']);
+    const first = runCli(['uninstall', '--yes']);
     expect(first.status).toBe(0);
     expect(first.stdout).toContain('uninstalled');
 
-    const second = runCli(['uninstall']);
+    const second = runCli(['uninstall', '--yes']);
     expect(second.status).toBe(0);
     expect(second.stdout).toContain('not registered');
     expect(second.stdout).toContain('nothing to uninstall');
   });
 
   test('uninstall on a clean host (no pm2 entries, no admin.json) exits 0 with diagnostic', () => {
-    const result = runCli(['uninstall']);
+    const result = runCli(['uninstall', '--yes']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('not registered');
     expect(result.stdout).toContain('nothing to uninstall');
@@ -273,7 +275,7 @@ describe('autopg uninstall — install round-trip (no Tier-B-refusal false posit
       port: 5432,
       installedAt: '2026-05-08T07:30:00.000Z',
     });
-    runCli(['uninstall']);
+    runCli(['uninstall', '--yes']);
 
     // --no-pm2 keeps the install fully hermetic (no real pm2 register
     // needed) and still exercises the assertSupervisor path. On a clean
@@ -293,7 +295,7 @@ describe('autopg uninstall — install round-trip (no Tier-B-refusal false posit
 describe('autopg uninstall — audit log', () => {
   test('appends one JSONL entry with event=autopg_uninstall to <configDir>/audit.log', () => {
     spawnSync(path.join(stubBin.dir, 'pm2'), ['start', '/dev/null', '--name', 'autopg-server']);
-    runCli(['uninstall']);
+    runCli(['uninstall', '--yes']);
 
     const auditFile = path.join(tmpHome, 'audit.log');
     expect(fs.existsSync(auditFile)).toBe(true);
@@ -304,5 +306,104 @@ describe('autopg uninstall — audit log', () => {
     expect(last.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(last.pm2Available).toBe(true);
     expect(Array.isArray(last.pm2)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #146: `autopg uninstall --help` executed the uninstall (args were
+// dropped at the dispatcher) and took down a live postmaster. `--help`,
+// bad flags and the confirmation gate must all return BEFORE any pm2 call.
+// runCli() spawns with piped stdio, so every test below is non-TTY.
+// ---------------------------------------------------------------------------
+
+describe('autopg uninstall — --help never touches pm2 (issue #146)', () => {
+  const SUPERVISOR = { supervisor: 'pm2', socketDir: '/tmp/x', port: 8432, installedAt: 'now' };
+
+  test('--help prints usage, exits 0, makes no pm2 call, leaves admin.json alone', () => {
+    seedAdminJson(SUPERVISOR);
+    const result = runCli(['uninstall', '--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage: autopg uninstall');
+    expect(result.stdout).toContain('--yes');
+    expect(readCallLog(stubBin.calls)).toEqual([]);
+    expect(readAdminJsonOnDisk()).toEqual(SUPERVISOR);
+  });
+
+  test('-h is an alias for --help', () => {
+    const result = runCli(['uninstall', '-h']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage: autopg uninstall');
+    expect(readCallLog(stubBin.calls)).toEqual([]);
+  });
+
+  test('--help wins even when combined with --yes', () => {
+    seedAdminJson(SUPERVISOR);
+    const result = runCli(['uninstall', '--yes', '--help']);
+    expect(result.status).toBe(0);
+    expect(readCallLog(stubBin.calls)).toEqual([]);
+    expect(readAdminJsonOnDisk()).toEqual(SUPERVISOR);
+  });
+
+  test('unknown flag prints usage on stderr, exits 2, makes no pm2 call', () => {
+    seedAdminJson(SUPERVISOR);
+    const result = runCli(['uninstall', '--nuke']);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('unknown option --nuke');
+    expect(result.stderr).toContain('Usage: autopg uninstall');
+    expect(result.stdout).toBe('');
+    expect(readCallLog(stubBin.calls)).toEqual([]);
+    expect(readAdminJsonOnDisk()).toEqual(SUPERVISOR);
+  });
+});
+
+describe('autopg uninstall — confirmation gate', () => {
+  const SUPERVISOR = { supervisor: 'pm2', socketDir: '/tmp/x', port: 8432, installedAt: 'now' };
+
+  test('non-TTY without --yes exits 2 with a --yes hint and tears nothing down', () => {
+    runCli(['install', '--port', '18432']);
+    seedAdminJson(SUPERVISOR);
+    fs.writeFileSync(path.join(stubBin.dir, 'registered-autopg-server'), '');
+    const before = readCallLog(stubBin.calls).length;
+
+    const result = runCli(['uninstall']);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('--yes');
+    expect(result.stderr).toContain('data dir preserved');
+
+    const after = readCallLog(stubBin.calls).slice(before);
+    expect(after.filter((c) => c[0] === 'delete')).toEqual([]);
+    expect(fs.existsSync(path.join(stubBin.dir, 'registered-autopg-server'))).toBe(true);
+    expect(readAdminJsonOnDisk()).toEqual(SUPERVISOR);
+  });
+
+  test('--yes runs the existing teardown path', () => {
+    seedAdminJson(SUPERVISOR);
+    fs.writeFileSync(path.join(stubBin.dir, 'registered-autopg-server'), '');
+    const result = runCli(['uninstall', '--yes']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('uninstalled pm2 entries: autopg-server');
+    expect(readCallLog(stubBin.calls).some((c) => c[0] === 'delete' && c[1] === 'autopg-server')).toBe(true);
+    expect(readAdminJsonOnDisk()).toBeNull();
+  });
+
+  test('-y is an alias for --yes', () => {
+    seedAdminJson(SUPERVISOR);
+    const result = runCli(['uninstall', '-y']);
+    expect(result.status).toBe(0);
+    expect(readAdminJsonOnDisk()).toBeNull();
+  });
+});
+
+describe('parseUninstallArgs (pure)', () => {
+  test('recognises help / yes and their short aliases', () => {
+    expect(parseUninstallArgs([])).toEqual({ help: false, yes: false, unknown: [] });
+    expect(parseUninstallArgs(['--help'])).toEqual({ help: true, yes: false, unknown: [] });
+    expect(parseUninstallArgs(['-h'])).toEqual({ help: true, yes: false, unknown: [] });
+    expect(parseUninstallArgs(['--yes'])).toEqual({ help: false, yes: true, unknown: [] });
+    expect(parseUninstallArgs(['-y'])).toEqual({ help: false, yes: true, unknown: [] });
+  });
+
+  test('collects unknown tokens', () => {
+    expect(parseUninstallArgs(['--force', 'extra'])).toEqual({ help: false, yes: false, unknown: ['--force', 'extra'] });
   });
 });

--- a/tests/e2e/settings-flow.test.js
+++ b/tests/e2e/settings-flow.test.js
@@ -281,7 +281,7 @@ describe.skipIf(!RUN_DAEMON_E2E)('e2e: full daemon leg (gated)', () => {
 
   afterAll(() => {
     try {
-      execFileSync(process.execPath, [WRAPPER, 'uninstall'], {
+      execFileSync(process.execPath, [WRAPPER, 'uninstall', '--yes'], {
         stdio: 'ignore',
         env: { ...process.env, AUTOPG_CONFIG_DIR: tmpConfigDir },
       });


### PR DESCRIPTION
## Root cause

`dispatch()` in `src/cli-install.cjs` (`case 'uninstall'`) called `mod.runUninstall()` and dropped `args` on the floor, so `autopg uninstall --help` — or any flag — ran the real uninstall: `pm2 delete autopg-server autopg-ui` + supervisor record cleared. There was also no confirmation step in front of stopping the postmaster.

## Fix

- `src/cli-install.cjs`: forward `{ argv: args }` to `runUninstall`.
- `src/commands/uninstall.js`:
  - `parseUninstallArgs(argv)` (pure, exported) runs first. `--help` / `-h` prints usage to stdout and returns 0 before any pm2 or admin.json access — same short-circuit shape as the v2.6.1 `install --help` fix. An unknown flag prints usage on stderr and returns 2.
  - Confirmation gate: on a TTY (`stdin.isTTY && stdout.isTTY`) prompts `This stops autopg-server/autopg-ui under pm2 (data dir preserved). Continue? [y/N]`; `--yes` / `-y` (or programmatic `opts.yes`) skips it; a non-interactive terminal without `--yes` returns 2 with a `Re-run with --yes` hint and touches nothing.
  - `runUninstall` is now `async` (the wrapper already resolves Promise exit codes). `opts.silent` / `opts.configDir` behave as before.
- Callers audited: no `scripts/`, `Makefile`, `install.sh` or workflow invokes `autopg uninstall`. The three test call sites (`tests/cli/uninstall.test.js`, `tests/cli-install.test.js`, `tests/e2e/settings-flow.test.js`) now pass `--yes`. `install --redeploy` does its own pm2 delete and is unaffected.
- README: notes the prompt and `--yes`.

## Tests

New in `tests/cli/uninstall.test.js` (9 tests, real wrapper against the stub `pm2`):
- `--help` → exit 0, prints usage, pm2 call log stays empty, seeded `admin.json` untouched; `-h` alias; `--help` wins over `--yes`.
- unknown flag (`--nuke`) → exit 2, usage on stderr, no pm2 call.
- non-TTY without `--yes` → exit 2 with `--yes` hint, no `pm2 delete`, sentinel + `admin.json` intact.
- `--yes` runs the existing teardown; `-y` alias.
- `parseUninstallArgs` unit cases.

- `bun run test`: 704 pass, 3 skip, 0 fail (707 tests across 49 files) — baseline on `main` was 695 pass / 3 skip / 0 fail
- `bun run lint`: clean
- `bun run deadcode`: clean

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DFsrEGgS79a6ELNUE38Dh
